### PR TITLE
feat: sort Chinese app labels by pinyin

### DIFF
--- a/app/src/main/java/com/github/codeworkscreativehub/mlauncher/MainViewModel.kt
+++ b/app/src/main/java/com/github/codeworkscreativehub/mlauncher/MainViewModel.kt
@@ -32,6 +32,7 @@ import com.github.codeworkscreativehub.mlauncher.data.Constants.AppDrawerFlag
 import com.github.codeworkscreativehub.mlauncher.data.ContactCategory
 import com.github.codeworkscreativehub.mlauncher.data.ContactListItem
 import com.github.codeworkscreativehub.mlauncher.data.Prefs
+import com.github.codeworkscreativehub.mlauncher.helper.ChineseSortHelper
 import com.github.codeworkscreativehub.mlauncher.helper.analytics.AppUsageMonitor
 import com.github.codeworkscreativehub.mlauncher.helper.ismlauncherDefault
 import com.github.codeworkscreativehub.mlauncher.helper.logActivitiesFromPackage
@@ -497,7 +498,13 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         list.forEachIndexed { index, item ->
             val label = getLabel(item)
             val pinned = pinnedStatusMap[item] == true
-            val key = if (pinned) "★" else label.firstOrNull()?.uppercaseChar()?.toString() ?: "#"
+            val key = if (pinned) {
+                "★"
+            } else {
+                ChineseSortHelper.sectionKey(label, prefs.appLanguage)
+                    ?: label.firstOrNull()?.uppercaseChar()?.toString()
+                    ?: "#"
+            }
             scrollMap.putIfAbsent(key, index)
         }
 
@@ -797,10 +804,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     // Helper: cheap normalization for sorting
     // Removes diacritics/unsupported characters cheaply and collapses whitespace.
     private fun normalizeForSort(s: String): String {
+        val source = ChineseSortHelper.sortKey(s, prefs.appLanguage) ?: s
+
         // Keep letters, digits and spaces. Collapse multiple spaces. Lowercase using default locale.
-        val sb = StringBuilder(s.length)
+        val sb = StringBuilder(source.length)
         var lastWasSpace = false
-        for (ch in s) {
+        for (ch in source) {
             if (ch.isLetterOrDigit()) {
                 sb.append(ch.lowercaseChar())
                 lastWasSpace = false

--- a/app/src/main/java/com/github/codeworkscreativehub/mlauncher/helper/ChineseSortHelper.kt
+++ b/app/src/main/java/com/github/codeworkscreativehub/mlauncher/helper/ChineseSortHelper.kt
@@ -1,0 +1,63 @@
+package com.github.codeworkscreativehub.mlauncher.helper
+
+import android.icu.text.Transliterator
+import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
+import com.github.codeworkscreativehub.mlauncher.data.Constants
+import java.util.Locale
+
+object ChineseSortHelper {
+    @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.Q)
+    private val platformSupported: Boolean
+        get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+
+    /**
+     * Returns a pinyin-based sort key only when the app language is Chinese, or follows a
+     * Chinese system language, and the platform supports ICU transliteration.
+     * Callers should fall back to the original label.
+     */
+    fun sortKey(label: String, language: Constants.Language): String? {
+        if (!shouldUseChineseSort(language) || !label.startsWithChinese()) return null
+
+        return transliterate(label)
+            ?.takeIf { it.isNotBlank() }
+            ?.lowercase(Locale.ROOT)
+    }
+
+    /**
+     * Returns a pinyin-based section letter only when the app language is Chinese, or follows a
+     * Chinese system language, and the platform supports ICU transliteration.
+     * Callers should fall back to the label's first char.
+     */
+    fun sectionKey(label: String, language: Constants.Language): String? {
+        if (!shouldUseChineseSort(language)) return null
+        val firstChar = label.firstOrNull()?.takeIf(::isChinese) ?: return null
+
+        return transliterate(firstChar.toString())
+            ?.firstOrNull { it.isLetter() }
+            ?.uppercaseChar()
+            ?.takeIf { it in 'A'..'Z' }
+            ?.toString()
+    }
+
+    private fun transliterate(label: String): String? {
+        if (!platformSupported) return null
+
+        return runCatching {
+            Transliterator.getInstance("Han-Latin; Latin-ASCII").transliterate(label)
+        }.getOrNull()
+    }
+
+    private fun shouldUseChineseSort(language: Constants.Language): Boolean =
+        platformSupported && when (language) {
+            Constants.Language.Chinese -> true
+            Constants.Language.System -> Locale.getDefault().language == Locale.CHINESE.language
+            else -> false
+        }
+
+    private fun String.startsWithChinese(): Boolean =
+        firstOrNull()?.let(::isChinese) == true
+
+    private fun isChinese(ch: Char): Boolean =
+        ch in '\u4E00'..'\u9FFF'
+}

--- a/app/src/main/java/com/github/codeworkscreativehub/mlauncher/ui/AppDrawerFragment.kt
+++ b/app/src/main/java/com/github/codeworkscreativehub/mlauncher/ui/AppDrawerFragment.kt
@@ -52,6 +52,7 @@ import com.github.codeworkscreativehub.mlauncher.data.Constants.AppDrawerFlag
 import com.github.codeworkscreativehub.mlauncher.data.ContactListItem
 import com.github.codeworkscreativehub.mlauncher.data.Prefs
 import com.github.codeworkscreativehub.mlauncher.databinding.FragmentAppDrawerBinding
+import com.github.codeworkscreativehub.mlauncher.helper.ChineseSortHelper
 import com.github.codeworkscreativehub.mlauncher.helper.emptyString
 import com.github.codeworkscreativehub.mlauncher.helper.getHexForOpacity
 import com.github.codeworkscreativehub.mlauncher.helper.hasContactsPermission
@@ -304,7 +305,11 @@ class AppDrawerFragment : BaseFragment() {
 
                 val sectionLetter = when (item.category) {
                     AppCategory.PINNED -> "★"
-                    else -> item.activityLabel.firstOrNull()?.uppercaseChar()?.toString() ?: return
+                    else -> {
+                        ChineseSortHelper.sectionKey(item.activityLabel, prefs.appLanguage)
+                            ?: item.activityLabel.firstOrNull()?.uppercaseChar()?.toString()
+                            ?: return
+                    }
                 }
 
                 // Skip redundant updates
@@ -858,10 +863,9 @@ class AppDrawerFragment : BaseFragment() {
             when (item.category) {
                 AppCategory.PINNED -> letters.add("★")
                 else -> {
-                    item.activityLabel.firstOrNull()
-                        ?.uppercaseChar()
-                        ?.toString()
-                        ?.let { letters.add(it) }
+                    val sectionLetter = ChineseSortHelper.sectionKey(item.activityLabel, prefs.appLanguage)
+                        ?: item.activityLabel.firstOrNull()?.uppercaseChar()?.toString()
+                    sectionLetter?.let { letters.add(it) }
                 }
             }
         }


### PR DESCRIPTION
### Type of Change <!-- Required -->

<!-- Select one type by placing an 'X' inside the appropriate box, and delete all others. -->

- [x] Feature <!-- Adds new user-facing functionality -->

---

### Pre-Submission Checklist <!-- Required -->

- [x] No existing [Pull Request](../../../pulls) for this change
- [x] Descriptive commit message
- [x] Self-reviewed the code
- [x] Comments added where necessary
- [x] No new warnings or errors introduced
- [x] Changes made in a separate branch
- [x] Branch named using prefix (e.g., `bug/`, `feat/`, `clean/`, `release/`)
- [x] All user-facing text supports localization (if applicable)
- [x] Updated documentation or relevant README sections (if applicable)
- [ ] Added screenshots or demo for UI changes (if applicable)

---

### Before Submitting Your Pull Request

- [x] Clear and descriptive PR title <!-- Required -->
- [x] Detailed summary of the changes made <!-- Required -->
- [ ] Linked relevant issue(s) using `Closes #XXXX` or `Fixes #XXXX` (if applicable)

---

### Summary of Changes

<!-- Provide a clear, concise overview of the changes in this PR, including context, motivation, and any dependencies. -->
Adds pinyin-based sorting and section indexing for Chinese app labels only when the launcher language is Chinese, or when it follows a Chinese system language.

#### Key Changes

1. Added `ChineseSortHelper` to centralize Chinese-specific sorting behavior.
   - Chinese sorting is only enabled when the app language is set to Chinese, or when the app follows the system language and the system language is Chinese.
   - Other app language settings keep the existing sorting behavior unchanged.
   - The helper returns `null` outside this narrow Chinese-language scope, so callers naturally fall back to the original label-based sorting.

2. Updated app list sorting to use pinyin keys only in Chinese-language contexts.
   - `MainViewModel.normalizeForSort()` asks `ChineseSortHelper.sortKey(...)` for a pinyin sort key.
   - A pinyin key is only produced for Chinese-leading labels in a Chinese-language context.
   - Non-Chinese language contexts and non-Chinese-leading labels continue through the existing normalization path.

3. Updated App Drawer section indexing to use pinyin initials only in Chinese-language contexts.
   - App list scroll mapping and the A-Z sidebar ask `ChineseSortHelper.sectionKey(...)` for a pinyin initial.
   - Chinese app names can appear under their pinyin initials, such as `微信` under `W`.
   - Pinned apps still use the existing `★` section, and all labels outside the Chinese-language scope keep the previous first-character section behavior.

---

### Test Information <!-- Required -->

- **MultiLauncher Version:** `b947f47`
- **Device Name:** Android Emulator
- **Android Version:** Android 17 and Android 9 / API 28
- **Other Notes:** Android 17 uses pinyin sorting correctly for Chinese app names. Android 9 / API 28 falls back to the existing sorting behavior correctly because ICU transliteration is only used on API 29+.
